### PR TITLE
Enhance desktop layout with retro style

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -15,6 +15,10 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/frontend/src/components/MonsterCard.css
+++ b/frontend/src/components/MonsterCard.css
@@ -4,7 +4,8 @@
   padding: 15px;
   margin: 10px 0;
   border-radius: 10px;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.5);
+  border: 2px solid #4a148c;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -13,6 +14,7 @@
 .monster-info h3 {
   margin: 0;
   font-size: 20px;
+  text-shadow: 2px 2px #000;
 }
 
 .slay-button {
@@ -24,8 +26,10 @@
   font-weight: bold;
   cursor: pointer;
   transition: 0.2s;
+  box-shadow: 0 2px 0 #722;
 }
 
 .slay-button:hover {
   background: darkred;
+  transform: translateY(-2px);
 }

--- a/frontend/src/components/Navigation.css
+++ b/frontend/src/components/Navigation.css
@@ -5,10 +5,11 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  background: purple;
+  background: #4a148c;
   color: white;
-  padding: 10px 0;
+  padding: 12px 0;
   z-index: 100;
+  box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.4);
 }
 
 .nav a {
@@ -16,7 +17,7 @@
   text-decoration: none;
   flex: 1;
   text-align: center;
-  font-size: 14px;
+  font-size: 16px;
 }
 
 .nav a.active {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,12 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Arial',
-    sans-serif;
+  font-family: 'Press Start 2P', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', 'Arial', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f8f9fa;
+  background: linear-gradient(#2b2b2b, #000);
+  color: #f1f1f1;
 }
 
 .page {
@@ -16,9 +17,24 @@ body {
   margin-right: auto;
 }
 
+@media (min-width: 768px) {
+  .page {
+    max-width: 900px;
+  }
+
+  .nav {
+    padding: 15px 0;
+  }
+
+  .nav a {
+    font-size: 18px;
+  }
+}
+
 h2 {
   color: #4a148c;
   font-size: 1.4rem;
+  text-shadow: 2px 2px #000;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- load Press Start 2P font
- apply retro background and font to the body
- improve navigation style
- widen page width on larger screens
- add game-like styling to monster cards

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `./backend/gradlew test --console=plain` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68539bb04cac8322abc563188f64c3ce