### PR TITLE
Implement basic XP leveling

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -19,6 +19,7 @@
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
       rel="stylesheet"
     />
+    <script src="https://cdn.tailwindcss.com"></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ function App() {
     { id: 2, title: 'Troll Blockade', difficulty: 'Hard', xp: 100, type: 'weekly' }
   ]);
   const [xp, setXp] = useState(0);
+  const [level, setLevel] = useState(1);
 
   const addTask = (task) => {
     const xpMap = { Easy: 50, Medium: 75, Hard: 100 };
@@ -30,21 +31,27 @@ function App() {
   const completeTask = (id) => {
     const task = tasks.find(t => t.id === id);
     if (task) {
-      setXp(prev => prev + task.xp);
-      toast.success(`+${task.xp} XP! 건타 처치: ${task.title}`);
+      setXp(prevXp => {
+        const totalXp = prevXp + task.xp;
+        const levelUps = Math.floor(totalXp / 100);
+        if (levelUps > 0) {
+          setLevel(prev => prev + levelUps);
+        }
+        return totalXp % 100;
+      });
+      toast.success(`✨ ${task.title} defeated! XP +${task.xp}!`);
     }
     setTasks(prev => prev.filter(t => t.id !== id));
   };
 
-  const calculateLevel = (xp) => Math.floor(xp / 100) + 1;
 
   return (
     <Router>
       <div className="App">
         <Routes>
           <Route path="/" element={<TaskPage tasks={tasks} completeTask={completeTask} />} />
-          <Route path="/status" element={<StatusPage xp={xp} level={calculateLevel(xp)} />} />
-          <Route path="/mypage" element={<MyPage xp={xp} level={calculateLevel(xp)} />} />
+          <Route path="/status" element={<StatusPage xp={xp} level={level} />} />
+          <Route path="/mypage" element={<MyPage xp={xp} level={level} />} />
           <Route path="/create" element={<CreateTaskPage addTask={addTask} />} />
         </Routes>
         <FloatingAddButton />

--- a/frontend/src/components/MonsterCard.jsx
+++ b/frontend/src/components/MonsterCard.jsx
@@ -9,7 +9,7 @@ function MonsterCard({ task, onComplete }) {
         <p>난이도: {task.difficulty}</p>
         <p>XP: +{task.xp}</p>
       </div>
-      <button className="slay-button" onClick={() => onComplete(task.id)}>⚔️ 처치</button>
+      <button className="slay-button hover:scale-105" onClick={() => onComplete(task.id)}>⚔️ 처치</button>
     </div>
   );
 }

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -6,10 +6,10 @@ function Navigation() {
   const { pathname } = useLocation();
 
   return (
-    <nav className="nav">
-      <Link to="/" className={pathname === '/' ? 'active' : ''}>Tasks</Link>
-      <Link to="/status" className={pathname === '/status' ? 'active' : ''}>Status</Link>
-      <Link to="/mypage" className={pathname === '/mypage' ? 'active' : ''}>My Page</Link>
+    <nav className="nav shadow-xl">
+      <Link to="/" className={`${pathname === '/' ? 'active' : ''} hover:scale-105`}>Tasks</Link>
+      <Link to="/status" className={`${pathname === '/status' ? 'active' : ''} hover:scale-105`}>Status</Link>
+      <Link to="/mypage" className={`${pathname === '/mypage' ? 'active' : ''} hover:scale-105`}>My Page</Link>
     </nav>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
 body {
   margin: 0;
   font-family: 'Press Start 2P', -apple-system, BlinkMacSystemFont, 'Segoe UI',

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -8,7 +8,7 @@ function MyPage({ xp, level }) {
       <div className="status-card">
         <h3>Warrior John</h3>
         <p>Level {level}</p>
-        <p>{xp} XP accumulated</p>
+          <p>{xp}/100 XP</p>
       </div>
       <div className="history-card">
         <h4>Completed Tasks</h4>

--- a/frontend/src/pages/StatusPage.jsx
+++ b/frontend/src/pages/StatusPage.jsx
@@ -10,9 +10,9 @@ function StatusPage({ xp, level }) {
         <h3>Sir Tasks-a-lot</h3>
         <p>Level {level}</p>
         <div className="xp-bar">
-          <div className="progress" style={{ width: `${xp % 100}%` }}></div>
+          <div className="progress" style={{ width: `${xp}%` }}></div>
         </div>
-        <p>{xp} XP</p>
+        <p>{xp}/100 XP</p>
         <h4>Equipped Items</h4>
         <div className="items">
           <span>🔪</span>

--- a/frontend/src/pages/StatusPage.jsx
+++ b/frontend/src/pages/StatusPage.jsx
@@ -4,7 +4,7 @@ import './StatusPage.css';
 function StatusPage({ xp, level }) {
   return (
     <div className="page status-page">
-      <h2>Status</h2>
+      <h2 className="shadow-xl">Status</h2>
       <div className="status-card">
         <img src="https://i.imgur.com/dtE9A7r.png" alt="avatar" className="avatar" />
         <h3>Sir Tasks-a-lot</h3>

--- a/frontend/src/pages/TaskPage.css
+++ b/frontend/src/pages/TaskPage.css
@@ -29,3 +29,21 @@
   padding: 8px;
   cursor: pointer;
 }
+
+.filter-buttons {
+  margin-bottom: 10px;
+}
+
+.filter-buttons button {
+  margin-right: 5px;
+  background: #444;
+  color: #fff;
+  border: none;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.filter-buttons button:hover {
+  background: #666;
+}

--- a/frontend/src/pages/TaskPage.jsx
+++ b/frontend/src/pages/TaskPage.jsx
@@ -11,11 +11,11 @@ function TaskPage({ tasks, completeTask }) {
 
   return (
     <div className="page">
-      <h2>퀘스트 목록</h2>
+      <h2 className="shadow-xl">퀘스트 목록</h2>
       <div className="filter-buttons">
-        <button onClick={() => setDifficultyFilter('All')}>All</button>
-        <button onClick={() => setDifficultyFilter('Easy')}>Easy</button>
-        <button onClick={() => setDifficultyFilter('Hard')}>Hard</button>
+        <button className="hover:scale-105" onClick={() => setDifficultyFilter('All')}>All</button>
+        <button className="hover:scale-105" onClick={() => setDifficultyFilter('Easy')}>Easy</button>
+        <button className="hover:scale-105" onClick={() => setDifficultyFilter('Hard')}>Hard</button>
       </div>
       {filteredTasks.map((task) => (
         <MonsterCard key={task.id} task={task} onComplete={completeTask} />

--- a/frontend/src/pages/TaskPage.jsx
+++ b/frontend/src/pages/TaskPage.jsx
@@ -1,12 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import MonsterCard from '../components/MonsterCard';
 import './TaskPage.css';
 
 function TaskPage({ tasks, completeTask }) {
+  const [difficultyFilter, setDifficultyFilter] = useState('All');
+
+  const filteredTasks = tasks.filter(
+    (task) => difficultyFilter === 'All' || task.difficulty === difficultyFilter
+  );
+
   return (
     <div className="page">
       <h2>퀘스트 목록</h2>
-      {tasks.map(task => (
+      <div className="filter-buttons">
+        <button onClick={() => setDifficultyFilter('All')}>All</button>
+        <button onClick={() => setDifficultyFilter('Easy')}>Easy</button>
+        <button onClick={() => setDifficultyFilter('Hard')}>Hard</button>
+      </div>
+      {filteredTasks.map((task) => (
         <MonsterCard key={task.id} task={task} onComplete={completeTask} />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- add level state to track leveling
- update completeTask to handle XP overflow
- display progress with XP/100 on status pages
- filter quests by difficulty and show a toast message on completion

## Testing
- `npm test --silent --runTestsByPath src/App.test.js` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b2e4cbe08322b77c3e8d3f952008