### PR TITLE
Add RPG stat system with HUD improvements

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,9 +18,13 @@ function App() {
   const [xp, setXp] = useState(0);
   const [level, setLevel] = useState(1);
   const [coins, setCoins] = useState(0);
+  const [stats, setStats] = useState({ STR: 1, DEX: 1, INT: 1, VIT: 1 });
+  const [statPoints, setStatPoints] = useState(0);
   const [completed, setCompleted] = useState([]);
   const [theme, setTheme] = useState('dark');
   const prevLevel = useRef(1);
+  const maxHp = 100 + stats.VIT * 10;
+  const hp = maxHp;
 
   useEffect(() => {
     document.body.className = `theme-${theme}`;
@@ -51,6 +55,12 @@ function App() {
     }
   };
 
+  const allocateStat = (key) => {
+    if (statPoints <= 0) return;
+    setStats(prev => ({ ...prev, [key]: prev[key] + 1 }));
+    setStatPoints(prev => prev - 1);
+  };
+
   const completeTask = (id) => {
     const task = tasks.find(t => t.id === id);
     if (task) {
@@ -61,6 +71,7 @@ function App() {
         const levelUps = Math.floor(totalXp / 100);
         if (levelUps > 0) {
           setLevel(prev => prev + levelUps);
+          setStatPoints(prev => prev + levelUps * 5);
           window.confetti && window.confetti();
         }
         return totalXp % 100;
@@ -78,12 +89,12 @@ function App() {
       <div className="App">
         <Routes>
           <Route path="/" element={<TaskPage tasks={tasks} completeTask={completeTask} />} />
-          <Route path="/status" element={<StatusPage xp={xp} level={level} />} />
+          <Route path="/status" element={<StatusPage xp={xp} level={level} stats={stats} statPoints={statPoints} allocateStat={allocateStat} />} />
           <Route path="/mypage" element={<MyPage xp={xp} level={level} completed={completed} setTheme={setTheme} theme={theme} coins={coins} />} />
           <Route path="/mypage" element={<MyPage xp={xp} level={level} />} />
           <Route path="/create" element={<CreateTaskPage addTask={addTask} />} />
         </Routes>
-        <HUD level={level} xp={xp} coins={coins} />
+        <HUD level={level} xp={xp} coins={coins} hp={hp} maxHp={maxHp} />
         <FloatingAddButton />
         <Navigation />
         <ToastContainer position="bottom-center" autoClose={1500} hideProgressBar={true} />

--- a/frontend/src/components/HUD.css
+++ b/frontend/src/components/HUD.css
@@ -1,3 +1,4 @@
 .hud {
   z-index: 200;
+  color: var(--font-color);
 }

--- a/frontend/src/components/HUD.jsx
+++ b/frontend/src/components/HUD.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import './HUD.css';
 
-function HUD({ level, xp, coins }) {
+function HUD({ level, xp, coins, hp, maxHp }) {
   return (
-    <div className="hud fixed top-0 left-0 w-full bg-black bg-opacity-70 text-white flex justify-around items-center p-2 shadow-xl">
+    <div className="hud fixed top-0 left-0 w-full bg-black bg-opacity-70 flex justify-around items-center p-2 shadow-xl">
+      <div>HP {hp}/{maxHp}</div>
       <div>Lvl {level}</div>
       <div className="hud-bar flex-1 mx-2 bg-gray-700 rounded h-2">
         <div className="bg-purple-500 h-2 rounded" style={{ width: `${xp}%` }}></div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,17 +11,23 @@ body {
   background-attachment: fixed;
   background-repeat: no-repeat;
   background-size: cover;
-  color: black;
+  --font-color: #f1f1f1;
+  color: var(--font-color);
 }
 
 .theme-light {
   background: linear-gradient(#ffffff, #dddddd);
-  color: #222;
+  --font-color: #222;
 }
 
 .theme-fantasy {
   background: linear-gradient(#f5e8c7, #e1c883);
-  color: #3b2f1c;
+  --font-color: #3b2f1c;
+}
+
+.theme-dark {
+  background: linear-gradient(#2b2b2b, #000);
+  --font-color: #f1f1f1;
 }
 
 .page {

--- a/frontend/src/pages/StatusPage.css
+++ b/frontend/src/pages/StatusPage.css
@@ -36,3 +36,13 @@
 .items span {
   font-size: 24px;
 }
+
+.stats div {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+}
+
+.stats button {
+  padding: 0 6px;
+}

--- a/frontend/src/pages/StatusPage.jsx
+++ b/frontend/src/pages/StatusPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import './StatusPage.css';
 
-function StatusPage({ xp, level }) {
+function StatusPage({ xp, level, stats, statPoints, allocateStat }) {
   return (
     <div className="page status-page">
       <h2 className="shadow-xl">Status</h2>
@@ -13,6 +13,15 @@ function StatusPage({ xp, level }) {
           <div className="progress" style={{ width: `${xp}%` }}></div>
         </div>
         <p>{xp}/100 XP</p>
+        <p>Stat Points: {statPoints}</p>
+        <div className="stats">
+          {['STR','DEX','INT','VIT'].map(key => (
+            <div key={key}>
+              {key}: {stats[key]}{' '}
+              <button onClick={() => allocateStat(key)} disabled={statPoints === 0}>+</button>
+            </div>
+          ))}
+        </div>
         <h4>Equipped Items</h4>
         <div className="items">
           <span>🔪</span>


### PR DESCRIPTION
## Summary
- allow players to allocate STR/DEX/INT/VIT stats
- show remaining stat points on the status page with buttons
- display HP/XP/Level/Coins in the HUD
- theme controls font color using CSS variables

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c217bedc83229e7f648cf3a1ebd6