### PR TITLE
Implement simple backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # TODO-RPG-APP
+
+This project contains a simple React frontend and a Spring Boot backend. The backend now exposes a small REST API using an in-memory H2 database.
+
+## API Endpoints
+
+- `POST /api/tasks` – create a new task. Body fields: `title`, `difficulty` (Easy/Medium/Hard), `type`.
+- `GET /api/tasks` – list all incomplete tasks.
+- `PUT /api/tasks/{id}` – mark a task as completed. Updates player XP and coins.
+- `GET /api/status` – return the current player level, XP and coins.
+
+CORS is enabled for all origins so the frontend can fetch data without issues.

--- a/backend/src/main/java/com/example/backend/DatabaseLoader.java
+++ b/backend/src/main/java/com/example/backend/DatabaseLoader.java
@@ -1,0 +1,37 @@
+package com.example.backend;
+
+import com.example.backend.entity.Player;
+import com.example.backend.entity.Task;
+import com.example.backend.repository.PlayerRepository;
+import com.example.backend.repository.TaskRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DatabaseLoader {
+    @Bean
+    CommandLineRunner initData(PlayerRepository playerRepository, TaskRepository taskRepository) {
+        return args -> {
+            if (playerRepository.count() == 0) {
+                Player player = new Player();
+                playerRepository.save(player);
+            }
+            if (taskRepository.count() == 0) {
+                Task t1 = new Task();
+                t1.setTitle("Goblin Attack");
+                t1.setDifficulty("Easy");
+                t1.setType("daily");
+                t1.setXp(50);
+                taskRepository.save(t1);
+
+                Task t2 = new Task();
+                t2.setTitle("Troll Blockade");
+                t2.setDifficulty("Hard");
+                t2.setType("weekly");
+                t2.setXp(100);
+                taskRepository.save(t2);
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/example/backend/config/CorsConfig.java
+++ b/backend/src/main/java/com/example/backend/config/CorsConfig.java
@@ -1,0 +1,20 @@
+package com.example.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**").allowedOrigins("*")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/example/backend/controller/StatusController.java
+++ b/backend/src/main/java/com/example/backend/controller/StatusController.java
@@ -1,0 +1,24 @@
+package com.example.backend.controller;
+
+import com.example.backend.entity.Player;
+import com.example.backend.service.PlayerService;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/status")
+@CrossOrigin(origins = "*")
+public class StatusController {
+    private final PlayerService playerService;
+
+    public StatusController(PlayerService playerService) {
+        this.playerService = playerService;
+    }
+
+    @GetMapping
+    public Player getStatus() {
+        return playerService.getPlayer();
+    }
+}

--- a/backend/src/main/java/com/example/backend/controller/TaskController.java
+++ b/backend/src/main/java/com/example/backend/controller/TaskController.java
@@ -1,0 +1,49 @@
+package com.example.backend.controller;
+
+import com.example.backend.entity.Task;
+import com.example.backend.service.PlayerService;
+import com.example.backend.service.TaskService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+@CrossOrigin(origins = "*")
+public class TaskController {
+    private final TaskService taskService;
+    private final PlayerService playerService;
+
+    public TaskController(TaskService taskService, PlayerService playerService) {
+        this.taskService = taskService;
+        this.playerService = playerService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Task> createTask(@RequestBody Task request) {
+        int xp = switch (request.getDifficulty()) {
+            case "Medium" -> 75;
+            case "Hard" -> 100;
+            default -> 50;
+        };
+        request.setXp(xp);
+        request.setCompleted(false);
+        return ResponseEntity.ok(taskService.addTask(request));
+    }
+
+    @GetMapping
+    public List<Task> getTasks() {
+        return taskService.getIncompleteTasks();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> completeTask(@PathVariable Long id) {
+        Task task = taskService.completeTask(id);
+        if (task == null) {
+            return ResponseEntity.notFound().build();
+        }
+        playerService.addXp(task.getXp());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/example/backend/entity/Player.java
+++ b/backend/src/main/java/com/example/backend/entity/Player.java
@@ -1,0 +1,20 @@
+package com.example.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Player {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int level = 1;
+    private int xp = 0;
+    private int coins = 0;
+}

--- a/backend/src/main/java/com/example/backend/entity/Task.java
+++ b/backend/src/main/java/com/example/backend/entity/Task.java
@@ -1,0 +1,22 @@
+package com.example.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Task {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String difficulty;
+    private String type;
+    private int xp;
+    private boolean completed = false;
+}

--- a/backend/src/main/java/com/example/backend/repository/PlayerRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/PlayerRepository.java
@@ -1,0 +1,7 @@
+package com.example.backend.repository;
+
+import com.example.backend.entity.Player;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlayerRepository extends JpaRepository<Player, Long> {
+}

--- a/backend/src/main/java/com/example/backend/repository/TaskRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/TaskRepository.java
@@ -1,0 +1,10 @@
+package com.example.backend.repository;
+
+import com.example.backend.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findByCompletedFalse();
+}

--- a/backend/src/main/java/com/example/backend/service/PlayerService.java
+++ b/backend/src/main/java/com/example/backend/service/PlayerService.java
@@ -1,0 +1,39 @@
+package com.example.backend.service;
+
+import com.example.backend.entity.Player;
+import com.example.backend.repository.PlayerRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PlayerService {
+    private final PlayerRepository playerRepository;
+
+    public PlayerService(PlayerRepository playerRepository) {
+        this.playerRepository = playerRepository;
+    }
+
+    public Player getPlayer() {
+        return playerRepository.findAll().stream().findFirst().orElse(null);
+    }
+
+    @Transactional
+    public Player addXp(int xpToAdd) {
+        Player player = getPlayer();
+        if (player == null) return null;
+        int xp = player.getXp() + xpToAdd;
+        int level = player.getLevel();
+        while (xp >= getRequiredXp(level)) {
+            xp -= getRequiredXp(level);
+            level++;
+        }
+        player.setXp(xp);
+        player.setLevel(level);
+        player.setCoins(player.getCoins() + xpToAdd / 10);
+        return playerRepository.save(player);
+    }
+
+    private int getRequiredXp(int level) {
+        return (int)Math.floor(50 * Math.pow(level, 1.5));
+    }
+}

--- a/backend/src/main/java/com/example/backend/service/TaskService.java
+++ b/backend/src/main/java/com/example/backend/service/TaskService.java
@@ -1,0 +1,34 @@
+package com.example.backend.service;
+
+import com.example.backend.entity.Task;
+import com.example.backend.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class TaskService {
+    private final TaskRepository taskRepository;
+
+    public TaskService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    public List<Task> getIncompleteTasks() {
+        return taskRepository.findByCompletedFalse();
+    }
+
+    @Transactional
+    public Task addTask(Task task) {
+        return taskRepository.save(task);
+    }
+
+    @Transactional
+    public Task completeTask(Long id) {
+        Task task = taskRepository.findById(id).orElse(null);
+        if (task == null) return null;
+        task.setCompleted(true);
+        return taskRepository.save(task);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=backend
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- add REST API for tasks and player status
- use H2 memory database and seed some demo data
- enable CORS for the backend
- document the new endpoints in the README

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ffe7c50c83228529dae9861c738b